### PR TITLE
chore: configure H2 database

### DIFF
--- a/ecommerce/pom.xml
+++ b/ecommerce/pom.xml
@@ -40,6 +40,33 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+    <!-- Web -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- JPA -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+
+    <!-- H2 Database -->
+    <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <scope>runtime</scope>
+    </dependency>
+
+    <!-- Tests -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <scope>test</scope>
+    </dependency>
+
+
 	</dependencies>
 
 	<build>

--- a/ecommerce/src/main/resources/application.yaml
+++ b/ecommerce/src/main/resources/application.yaml
@@ -1,3 +1,19 @@
 spring:
   application:
     name: ecommerce
+
+  datasource:
+    url: jdbc:h2:mem:ecommerce-db
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true


### PR DESCRIPTION
What I did (#2) :
- Added dependencies for Spring Data JPA and H2 in pom.xml
- Configured H2 datasource and console in application.yaml

Why I did it:
- To set up an in-memory H2 database for the project
- This allows local testing of database operations