### PR TITLE
feat: implement ProductNotFoundException and add product retrieval endpoint

### DIFF
--- a/ecommerce/src/main/java/com/openspringlab/ecommerce/controller/GlobalExceptionHandler.java
+++ b/ecommerce/src/main/java/com/openspringlab/ecommerce/controller/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.openspringlab.ecommerce.controller;
+
+import com.openspringlab.ecommerce.product.ProductNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ProductNotFoundException.class)
+    public ResponseEntity<String> handleProductNotFound(ProductNotFoundException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+}

--- a/ecommerce/src/main/java/com/openspringlab/ecommerce/controller/ProductController.java
+++ b/ecommerce/src/main/java/com/openspringlab/ecommerce/controller/ProductController.java
@@ -1,0 +1,26 @@
+package com.openspringlab.ecommerce.controller;
+
+import com.openspringlab.ecommerce.product.Product;
+import com.openspringlab.ecommerce.product.ProductService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/products")
+public class ProductController {
+
+    private final ProductService productService;
+
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Product> getById(@PathVariable Long id) {
+        Product product = productService.getProductById(id);
+        return ResponseEntity.ok(product);
+    }
+}

--- a/ecommerce/src/main/java/com/openspringlab/ecommerce/product/ProductNotFoundException.java
+++ b/ecommerce/src/main/java/com/openspringlab/ecommerce/product/ProductNotFoundException.java
@@ -1,0 +1,7 @@
+package com.openspringlab.ecommerce.product;
+
+public class ProductNotFoundException extends RuntimeException {
+    public ProductNotFoundException(Long id) {
+        super("Product not found with id: " + id);
+    }
+}

--- a/ecommerce/src/main/java/com/openspringlab/ecommerce/product/ProductService.java
+++ b/ecommerce/src/main/java/com/openspringlab/ecommerce/product/ProductService.java
@@ -13,4 +13,9 @@ public class ProductService {
     public Product saveProduct(Product product) {
         return productRepository.save(product);
     }
+
+    public Product getProductById(Long id) {
+        return productRepository.findById(id)
+                .orElseThrow(() -> new ProductNotFoundException(id));
+    }
 }


### PR DESCRIPTION
What I Did

- Custom exception: Added ProductNotFoundException for missing products.
- Service change: Added [getProductById()] that throws the exception when absent.
- Global handler: Created a @ControllerAdvice to map the exception to HTTP 404.
- Demo endpoint: Added a minimal [GET /products/{id}] to exercise the flow.
Closes #13 