### PR TITLE
feat: implement Order CRUD operations and fix MapStruct configuration

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,10 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="ms-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
+  </component>
+  <component name="ProjectType">
+    <option name="id" value="jpab" />
   </component>
 </project>

--- a/ecommerce/pom.xml
+++ b/ecommerce/pom.xml
@@ -47,8 +47,10 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <optional>true</optional>
+            <version>1.18.32</version>
+            <scope>provided</scope>
         </dependency>
+
 
         <!-- VALIDATION -->
         <dependency>
@@ -70,6 +72,13 @@
             <version>1.5.5.Final</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>1.5.5.Final</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Tests -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -84,7 +93,48 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <annotationProcessorPaths>
+                        <!-- 1. LOMBOK MUST BE FIRST -->
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+
+                        <!-- 2. ADD THE BINDING -->
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
+                        </path>
+
+                        <!-- 3. MAPSTRUCT LAST -->
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+
         </plugins>
     </build>
 

--- a/ecommerce/src/main/java/com/openspringlab/ecommerce/controller/OrderController.java
+++ b/ecommerce/src/main/java/com/openspringlab/ecommerce/controller/OrderController.java
@@ -1,9 +1,14 @@
 package com.openspringlab.ecommerce.controller;
 
+import com.openspringlab.ecommerce.dto.order.CreateOrderRequest;
+import com.openspringlab.ecommerce.dto.order.OrderResponse;
+import com.openspringlab.ecommerce.dto.order.UpdateOrderRequest;
 import com.openspringlab.ecommerce.service.OrderService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/orders")
@@ -12,13 +17,36 @@ public class OrderController {
     private final OrderService orderService;
 
     //GET - /orders
+    @GetMapping
+    public ResponseEntity<List<OrderResponse>> getAllOrders(){
+        return ResponseEntity.ok(orderService.getAllOrders());
+    }
 
     //GET - /orders/{id}
+    @GetMapping("/{id}")
+    public ResponseEntity<OrderResponse> getOrderById(@PathVariable(name = "id") Long orderId){
+        return ResponseEntity.ok(orderService.getOrderById(orderId));
+    }
 
     //POST - /orders
+    @PostMapping
+    public ResponseEntity<OrderResponse> createOrder(@RequestBody CreateOrderRequest createOrderRequest){
+        return ResponseEntity.ok(orderService.createOrder(createOrderRequest));
+    }
 
     //PUT - /orders/{id}
+    @PutMapping("/{id}")
+    public ResponseEntity<OrderResponse> updateOrderItems(@PathVariable(name = "id") Long id,
+                                                          @RequestBody UpdateOrderRequest updateOrderRequest){
+        OrderResponse orderResponse = orderService.updateOrder(id, updateOrderRequest);
+        return ResponseEntity.ok(orderResponse);
+    }
 
     //DELETE - orders/{id}
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteOrder(@PathVariable(name = "id") Long id){
+        orderService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
 
 }

--- a/ecommerce/src/main/java/com/openspringlab/ecommerce/dto/order/item/OrderItemResponse.java
+++ b/ecommerce/src/main/java/com/openspringlab/ecommerce/dto/order/item/OrderItemResponse.java
@@ -11,4 +11,6 @@ public class OrderItemResponse {
     private Long productId;
     private Integer quantity;
     private BigDecimal price;
+    private BigDecimal totalPrice;
+
 }

--- a/ecommerce/src/main/java/com/openspringlab/ecommerce/exception/GlobalExceptionHandler.java
+++ b/ecommerce/src/main/java/com/openspringlab/ecommerce/exception/GlobalExceptionHandler.java
@@ -22,7 +22,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(OrderNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleOrderNotFoundException(OrderNotFoundException ex) {
         Map<String, String> errors = new HashMap<>();
-        errors.put("message", "Order not found !");
+        errors.put("message", ex.getMessage());
         return new ResponseEntity<>(errors, HttpStatus.NOT_FOUND);
     }
 

--- a/ecommerce/src/main/java/com/openspringlab/ecommerce/mapper/OrderItemMapper.java
+++ b/ecommerce/src/main/java/com/openspringlab/ecommerce/mapper/OrderItemMapper.java
@@ -23,7 +23,7 @@ public interface OrderItemMapper {
     OrderItemResponse toDto(OrderItem orderItem);
 
     @Named("getProductId")
-    private Long getProductId(Product product){
+    default Long getProductId(Product product){
         return  product.getId();
     }
 

--- a/ecommerce/src/main/java/com/openspringlab/ecommerce/mapper/ProductMapper.java
+++ b/ecommerce/src/main/java/com/openspringlab/ecommerce/mapper/ProductMapper.java
@@ -21,7 +21,7 @@
         ProductResponse toDto(Product product);
 
         @Named("getCategoryId")
-        private Long getCategoryId(Category category){
+        default Long getCategoryId(Category category){
             return category.getId();
         }
 

--- a/ecommerce/src/main/java/com/openspringlab/ecommerce/model/OrderItem.java
+++ b/ecommerce/src/main/java/com/openspringlab/ecommerce/model/OrderItem.java
@@ -30,4 +30,6 @@ public class OrderItem {
     private Integer quantity;
 
     private BigDecimal price;
+
+    private BigDecimal totalPrice;
 }

--- a/ecommerce/src/main/java/com/openspringlab/ecommerce/service/OrderService.java
+++ b/ecommerce/src/main/java/com/openspringlab/ecommerce/service/OrderService.java
@@ -1,22 +1,173 @@
 package com.openspringlab.ecommerce.service;
 
+import com.openspringlab.ecommerce.dto.order.CreateOrderRequest;
+import com.openspringlab.ecommerce.dto.order.OrderResponse;
+import com.openspringlab.ecommerce.dto.order.UpdateOrderRequest;
+import com.openspringlab.ecommerce.dto.order.item.CreateOrderItemRequest;
+import com.openspringlab.ecommerce.exception.OrderNotFoundException;
+import com.openspringlab.ecommerce.exception.ProductNotFoundException;
+import com.openspringlab.ecommerce.mapper.OrderItemMapper;
+import com.openspringlab.ecommerce.mapper.OrderMapper;
+import com.openspringlab.ecommerce.model.Order;
+import com.openspringlab.ecommerce.model.OrderItem;
+import com.openspringlab.ecommerce.model.Product;
 import com.openspringlab.ecommerce.repository.OrderRepository;
+import com.openspringlab.ecommerce.repository.ProductRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class OrderService {
     private final OrderRepository orderRepository;
+    private final OrderMapper orderMapper;
+    private final ProductRepository productRepository;
+    private final OrderItemMapper orderItemMapper;
 
     //getAll - List<OrderResponse>
+    public List<OrderResponse> getAllOrders() {
+        List<Order> orders = orderRepository.findAll();
+        return orders.stream().map(orderMapper::toDto)
+                .collect(Collectors.toList());
+    }
 
     //getById - OrderResponse
+    public OrderResponse getOrderById(Long id) {
+        Order order = orderRepository.findById(id)
+                .orElseThrow(() ->
+                        new OrderNotFoundException("Order with id " + id + " not found"));
+        return orderMapper.toDto(order);
+    }
 
     //create - OrderResponse
+    @Transactional
+    public OrderResponse createOrder(CreateOrderRequest createOrderRequest) {
+        // Fetch all products at once (solves N+1)
+        List<Long> productIds = createOrderRequest.getItems().stream()
+                .map(CreateOrderItemRequest::getProductId)
+                .toList();
+
+        Map<Long, Product> productMap = productRepository.findAllById(productIds)
+                .stream()
+                .collect(Collectors.toMap(Product::getId, Function.identity()));
+
+        // Validate all products exist
+        for (CreateOrderItemRequest item : createOrderRequest.getItems()) {
+            if (!productMap.containsKey(item.getProductId())) {
+                throw new ProductNotFoundException(
+                        "Product with id " + item.getProductId() + " not found"
+                );
+            }
+        }
+
+        Order order = new Order();
+        BigDecimal totalPrice = BigDecimal.ZERO;
+
+        for (CreateOrderItemRequest item : createOrderRequest.getItems()) {
+            Product product = productMap.get(item.getProductId());
+
+            // Optional: Validate stock
+             if (product.getStockQuantity() < item.getQuantity()) {
+                 throw new RuntimeException("Insufficient stock");
+             }
+
+            OrderItem orderItem = orderItemMapper.toEntity(item);
+            orderItem.setOrder(order);
+            orderItem.setProduct(product);
+            orderItem.setPrice(product.getPrice()); // Store unit price
+
+            BigDecimal itemTotal = product.getPrice()
+                    .multiply(BigDecimal.valueOf(item.getQuantity()));
+            orderItem.setTotalPrice(itemTotal);
+
+            totalPrice = totalPrice.add(itemTotal);
+            order.getOrderItems().add(orderItem);
+        }
+
+        order.setTotalAmount(totalPrice);
+
+        return orderMapper.toDto(orderRepository.save(order));
+    }
 
     //update - OrderResponse
+    @Transactional
+    public OrderResponse updateOrder(Long id, UpdateOrderRequest updateOrderRequest) {
+        Order order = orderRepository.findById(id)
+                .orElseThrow(() -> new OrderNotFoundException("Order with id " + id + " not found"));
+
+        // Map existing items by product ID for easy lookup
+        Map<Long, OrderItem> existingItems = order.getOrderItems().stream()
+                .collect(Collectors.toMap(
+                        item -> item.getProduct().getId(),
+                        Function.identity()
+                ));
+
+        // Fetch products
+        List<Long> productIds = updateOrderRequest.getItems().stream()
+                .map(CreateOrderItemRequest::getProductId)
+                .toList();
+        Map<Long, Product> productMap = productRepository.findAllById(productIds)
+                .stream()
+                .collect(Collectors.toMap(Product::getId, Function.identity()));
+
+        // Validate products exist
+        for (CreateOrderItemRequest item : updateOrderRequest.getItems()) {
+            if (!productMap.containsKey(item.getProductId())) {
+                throw new ProductNotFoundException(
+                        "Product with id " + item.getProductId() + " not found"
+                );
+            }
+        }
+
+        // Remove items not in the update request
+        order.getOrderItems().removeIf(
+                item -> !productIds.contains(item.getProduct().getId())
+        );
+
+        BigDecimal totalPrice = BigDecimal.ZERO;
+
+        // Update or add items
+        for (CreateOrderItemRequest itemRequest : updateOrderRequest.getItems()) {
+            Product product = productMap.get(itemRequest.getProductId());
+            OrderItem orderItem = existingItems.get(itemRequest.getProductId());
+
+            if (orderItem == null) {
+                // New item
+                orderItem = orderItemMapper.toEntity(itemRequest);
+                orderItem.setOrder(order);
+                orderItem.setProduct(product);
+                order.getOrderItems().add(orderItem);
+            } else {
+                // Update existing
+                orderItem.setQuantity(itemRequest.getQuantity());
+            }
+
+            orderItem.setPrice(product.getPrice());
+            BigDecimal itemTotal = product.getPrice()
+                    .multiply(BigDecimal.valueOf(itemRequest.getQuantity()));
+            orderItem.setTotalPrice(itemTotal);
+
+            totalPrice = totalPrice.add(itemTotal);
+        }
+
+        order.setTotalAmount(totalPrice);
+
+        return orderMapper.toDto(orderRepository.save(order));
+    }
 
     //deleteById - void
+    public void deleteById(Long id){
+        orderRepository.deleteById(id);
+    }
+    
 
 }


### PR DESCRIPTION
## ✨ Summary

This PR implements full CRUD operations for the **Order** module and fixes MapStruct-related configuration issues.

---

## ✅ What was done

- Implemented complete **Order CRUD functionality**:
  - Create Order (including order items)
  - Retrieve single and multiple Orders
  - Update Order details
  - Delete Order
- Fixed **MapStruct mapping issues** by properly adding the `mapstruct-processor`
- Updated `pom.xml` to ensure annotation processing works correctly
- Resolved DTO ↔ Entity mapping errors across the Order flow

---

## 🤔 Why this was done

- The Order module lacked full CRUD support, which is essential for core e-commerce functionality
- MapStruct mappers were not being generated due to missing processor configuration, causing compilation and runtime errors
- Proper MapStruct setup improves:
  - Code cleanliness
  - Build stability
  - Developer productivity

---

## 🛠️ Notes

- No breaking changes introduced
- Existing functionality remains unaffected
- Improves overall system reliability and maintainability
